### PR TITLE
Fixxing major bug

### DIFF
--- a/contracts/VotePoap.sol
+++ b/contracts/VotePoap.sol
@@ -149,14 +149,13 @@ contract VotePoap is Initializable, PoapRoles {
 
         Voter storage sender = voters[_sender];
 
-        uint weightedVote = _ceilLog2(tokensAmount);
-
         // Decrease vote from previous vote if existed
         if (sender.voted) {
             proposals[sender.voteOption].voteCount -= 1;
-            proposals[sender.voteOption].weightedVotes -= weightedVote;
+            proposals[sender.voteOption].weightedVotes -= sender.weightedVote;
         }
 
+        uint weightedVote = _ceilLog2(tokensAmount);
         sender.tokens = tokensAmount;
         sender.weightedVote = weightedVote;
         sender.voteOption = _proposal;


### PR DESCRIPTION
Changing votes with a different number of token could cause manipulation. Vote cleanup must strictly revert the previous vote